### PR TITLE
Update amazonannoyances.txt to bypass the Warranty Modal

### DIFF
--- a/amazonannoyances.txt
+++ b/amazonannoyances.txt
@@ -75,6 +75,7 @@
 /ajax/simple-pixels.html$domain=amazon.*|primevideo.com|imdb.com
 ||amazon.*/monitoring.html
 ||amazon.*/eventtracker.html
+||amazon.*/is-si-with-triggers.html
 ||amazon.*/reftag.html
 ||amazon.*/recordRefTag?
 ||amazon.*/record-ref.html


### PR DESCRIPTION
Add a bypass to the Warranty Modal slideover. Full request to block is `https://www.amazon.com/gp/si/util/is-si-with-triggers.html`.